### PR TITLE
[readme] Fix a typo on the link to the example: "Integration Test"

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ OkHttpClient client = new OkHttpClient.Builder()
                 .build();
 ```
 
-Check an example [Integration Test](src/test/java/okhttp3/m#ock/MockInterceptorITTest.java) with mocked HTTP responses
+Check an example [Integration Test](src/test/java/okhttp3/mock/MockInterceptorITTest.java) with mocked HTTP responses
 
 You can use the following helper classes to provide mock responses from resources:
 - `ClasspathResources.resource` to load content from classpath


### PR DESCRIPTION
The link "Integration Test" is broken as there's a `#` in the middle of the URL.