### PR TITLE
Fix stackoverflow in `patch` by setting method accordingly

### DIFF
--- a/library/src/main/java/okhttp3/mock/Rule.java
+++ b/library/src/main/java/okhttp3/mock/Rule.java
@@ -167,7 +167,7 @@ public class Rule {
         }
 
         public Builder patch() {
-            patch(PATCH);
+            method(PATCH);
             return this;
         }
 

--- a/library/src/test/java/okhttp3/mock/MockInterceptorITTest.java
+++ b/library/src/test/java/okhttp3/mock/MockInterceptorITTest.java
@@ -1,10 +1,12 @@
 package okhttp3.mock;
 
 import okhttp3.HttpUrl;
+import okhttp3.MediaType;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.Response;
 import okhttp3.ResponseBody;
+import okhttp3.RequestBody;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -211,4 +213,17 @@ public class MockInterceptorITTest {
         }
     }
 
+    @Test
+    public void testPatch() throws IOException {
+        final RequestBody body = RequestBody.create(MediaType.parse("application/json"), "{}");
+        interceptor.addRule()
+            .patch(TEST_URL)
+            .respond(TEST_RESPONSE);
+
+        client.newCall(new Request.Builder()
+            .url(TEST_URL)
+            .patch(body)
+            .build())
+            .execute();
+    }
 }


### PR DESCRIPTION
`patch` ran into a stackoverflow as it called `patch` again. Fixed by calling `method(PATCH)` instead.