### PR TITLE
Publishing as `com.github.gmazzo.okhttp.mock:mock-client`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # okhttp-client-mock
 A simple OKHttp client mock, using a programmable request interceptor
 
-[![Maven Central](https://img.shields.io/maven-central/v/com.github.gmazzo/okhttp-mock)](https://central.sonatype.com/artifact/com.github.gmazzo/okhttp-mock)
+[![Maven Central](https://img.shields.io/maven-central/v/com.github.gmazzo.okhttp.mock/mock-client)](https://central.sonatype.com/artifact/com.github.gmazzo.okhttp.mock/mock-client)
 [![Build Status](https://github.com/gmazzo/okhttp-client-mock/actions/workflows/build.yaml/badge.svg)](https://github.com/gmazzo/okhttp-client-mock/actions/workflows/build.yaml)
 [![codecov](https://codecov.io/gh/gmazzo/okhttp-client-mock/branch/master/graph/badge.svg)](https://codecov.io/gh/gmazzo/okhttp-client-mock)
 
@@ -9,7 +9,7 @@ A simple OKHttp client mock, using a programmable request interceptor
 On your `build.gradle` add:
 ```groovy
 dependencies {
-    testImplementation 'com.github.gmazzo:okhttp-mock:<version>'
+    testImplementation 'com.github.gmazzo.okhttp.mock:mock-client:<version>'
 }
 ```
 

--- a/buildSrc/src/main/kotlin/maven-central-publish.gradle.kts
+++ b/buildSrc/src/main/kotlin/maven-central-publish.gradle.kts
@@ -48,6 +48,7 @@ fun MavenPublication.setupMandatoryPOMAttributes() {
             .exec { commandLine("git", "remote", "get-url", "origin") }
             .standardOutput
             .asText
+            .map { it.trim() }
 
         name.set("${rootProject.name}-${project.name}")
         description.set(project.description)

--- a/library/src/main/java/okhttp3/mock/HttpCodes.java
+++ b/library/src/main/java/okhttp3/mock/HttpCodes.java
@@ -1,8 +1,0 @@
-package okhttp3.mock;
-
-/**
- * @deprecated replaced by {@link HttpCode}, will be removed on next version
- */
-@Deprecated
-public interface HttpCodes extends HttpCode {
-}

--- a/library/src/main/java/okhttp3/mock/HttpMethods.java
+++ b/library/src/main/java/okhttp3/mock/HttpMethods.java
@@ -1,8 +1,0 @@
-package okhttp3.mock;
-
-/**
- * @deprecated replaced by {@link HttpMethod}, will be removed on next version
- */
-@Deprecated
-public interface HttpMethods extends HttpMethod {
-}

--- a/library/src/main/java/okhttp3/mock/Rule.java
+++ b/library/src/main/java/okhttp3/mock/Rule.java
@@ -12,7 +12,7 @@ import java.nio.charset.Charset;
 import java.util.*;
 import java.util.regex.Pattern;
 
-import static okhttp3.mock.HttpCodes.HTTP_200_OK;
+import static okhttp3.mock.HttpCode.HTTP_200_OK;
 import static okhttp3.mock.HttpMethod.*;
 import static okhttp3.mock.MediaTypes.MEDIATYPE_RAW_DATA;
 import static okhttp3.mock.MediaTypes.MEDIATYPE_TEXT;


### PR DESCRIPTION
Changes:
- New Maven Coordinates (GAV) are `com.github.gmazzo.okhttp.mock:mock-client`
- Removed deprecated classes